### PR TITLE
Reload the data when ElectronData.get

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,6 +11,7 @@
   const home      = require('user-home');
   const mkdirp    = require('mkdirp');
   const fs        = require('fs');
+  const reload    = require('require-reload')(require);
 
 
   /**
@@ -61,23 +62,6 @@
         self.data = require(self.filepath);
       } catch(e) {
         fs.writeFileSync(self.filepath, JSON.stringify(self.data));
-      }
-
-
-      // autosave functionality
-      if (self.options.autosave) {
-        const objectChangeHandler = {
-          get: (target, property) => {
-            return target[property];
-          },
-          set: (target, property, value, receiver) => {
-            target[property] = value;
-            self.save();
-            return true;
-          }
-        };
-
-        self.data = new Proxy(self.data, objectChangeHandler);
       }
 
       return self;
@@ -135,6 +119,8 @@
       let self  = this,
         item    = null;
 
+      self.data = reload(self.filepath);
+
       if (!key) return self.data;
 
       for (let p in self.data) {
@@ -173,6 +159,9 @@
       if (err !== null) throw err;
 
       self.data[key] = value;
+
+      if (self.options.autosave) { self.save(); }
+
       return self.data;
     }
 
@@ -189,7 +178,11 @@
 
       let self = this;
 
-      return delete self.data[key];
+      let result = delete self.data[key]
+
+      if (self.options.autosave) { self.save(); }
+
+      return result;
     }
 
 

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   },
   "dependencies": {
     "mkdirp": "^0.5.1",
+    "require-reload": "^0.2.2",
     "user-home": "^2.0.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -198,6 +198,10 @@ path-is-absolute@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
 
+require-reload@^0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/require-reload/-/require-reload-0.2.2.tgz#29a7591846caf91b6e8a3cda991683f95f8d7d42"
+
 supports-color@3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-3.1.2.tgz#72a262894d9d408b956ca05ff37b2ed8a6e2a2d5"


### PR DESCRIPTION
* Because file data is not changed immediately in another process, reload (require-reload) the data when the ElectronData.get() method is called.
* Disuse the Proxy object because the self.data object came to change.
  * ElectronData.get() and ElectronData.unset() have effect of autosave.